### PR TITLE
Using main branch of outlines instead

### DIFF
--- a/llm_exl2_client_multi_outlines.py
+++ b/llm_exl2_client_multi_outlines.py
@@ -5,9 +5,6 @@ import logging
 import time
 import configparser
 import argparse
-import tiktoken
-import torch
-import random
 from typing import AsyncIterable, List, Generator, Union, Optional
 import traceback
 from typing import Mapping
@@ -26,6 +23,8 @@ import queue
 import numpy as np
 
 import sys, os
+assert os.path.exists("./outlines"), "Clone the outlines repository here with git clone https://github.com/outlines-dev/outlines"
+sys.path.append("./outlines")
 import outlines
 from outlines.samplers import multinomial
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))


### PR DESCRIPTION
This is to attempt the fix of the latest version of outlines having issues with llama 3 tokenizer which seems to be fixed in the main branch. The steps to have this take effect is
```
pip uninstall outlines
git clone https://github.com/outlines-dev/outlines.git
```