### PR TITLE
Radix cache

### DIFF
--- a/llm_exl2_client_multi_outlines.py
+++ b/llm_exl2_client_multi_outlines.py
@@ -65,9 +65,11 @@ class StoredKVCaches:
                     min_count = used_num
                     least_utilized_key = key
             del self.data[least_utilized_key]
-        self.data[prompt] = cache
+        self.data[prompt] = [0, cache]
     def get(self, prompt: str):
-        return self.data.get(prompt, None)
+        hits_and_cache = self.data.get(prompt, None)
+        hits_and_cache[0] += 1
+        return hits_and_cache[1]
 
 
 class CompletionRequest(BaseModel):

--- a/llm_exl2_client_multi_outlines.py
+++ b/llm_exl2_client_multi_outlines.py
@@ -510,7 +510,7 @@ def process_outline_prompts():
                             radix_cache.insert(prompt, model.cache.clone())
                     else:
                         model.cache = precomputed_cache_node.value
-                        print("Hit ", precomputed_cache_node.key)
+                        print("hit")
                         if prompt != precomputed_cache_node.key:
                             model.model.forward(
                                 ids[:-1].view(1, -1),


### PR DESCRIPTION
This is a proof of concept pr of radix-cache. The main inspiration is from https://github.com/sgl-project/sglang. We try to save the most important kv cache/prompt pair across requests so we can just start off from where we left off in the server. For example in chain of thought/tree of thought or any prompting where the LLM iteratively calls on the results of the previous prompt, especially with constrained generation(With constrained react agents this is very useful). Visualization from the paper is below
![image](https://github.com/blockentropy/ml-client/assets/23430101/ea095226-0367-46e8-a9dc-d7fe8f0695f5)

Currently, I'm doing a simplified version. Steps missing are

- [x] Find cache of matching for the beginning of the prompt
- [x] Testing locally
- [ ] Figure out how to move cache to cpu/device for exllama2
- [x] Probably use a way better data structure. But this is less of a priority for now as most of the time is spent processing tokens on gpus anyway
and I think this pr will be done.