### PR TITLE
Fix: Prevent infinite generation for Llama3 when stop_at is not reached

### DIFF
--- a/llm_exl2_dynamic_gen.py
+++ b/llm_exl2_dynamic_gen.py
@@ -470,7 +470,7 @@ def process_prompts():
                     job = ExLlamaV2DynamicJob(
                         input_ids = ids,
                         max_new_tokens = max_tokens,
-                        stop_conditions = preferred_eos if stop_at is None else [tokenizer.eos_token_id, stop_at],
+                        stop_conditions = preferred_eos,
                         gen_settings = gen_settings,
                         filters = filters,
                         token_healing = healing


### PR DESCRIPTION
## Problem
When using the Llama3 model with a `stop_at` parameter in the extra body, the generation continues indefinitely if the model doesn't output the specified `stop_at` string. This leads to unexpected behavior and potential resource waste.

## Solution
The fix involves modifying the stop conditions to only consider the `preferred_eos` variable. The `stop_at` parameter is already handled within `preferred_eos` in earlier steps of the process.

## Changes
- Updated the stop conditions to rely solely on `preferred_eos`

## Testing
- Verified that generation stops correctly when `stop_at` is reached
- Confirmed that generation completes normally when `stop_at` is not encountered
- Tested with various input prompts and `stop_at` values

Kindly review and let me know if any further modifications are needed.