### PR TITLE
Image client response type

### DIFF
--- a/image_client.py
+++ b/image_client.py
@@ -50,7 +50,7 @@ stable_diffusion = DiffusionPipeline.from_pretrained(repo_id, scheduler=schedule
 seed = 42
 generator = torch.Generator("cpu").manual_seed(seed)
 
-# stable_diffusion.load_ip_adapter(adapter_id, subfolder="sdxl_models", weight_name="ip-adapter_sdxl.bin")
+stable_diffusion.load_ip_adapter(adapter_id, subfolder="sdxl_models", weight_name="ip-adapter_sdxl.bin")
 
 stable_diffusion.to(f"cuda")
 
@@ -90,14 +90,14 @@ def image_request(prompt: str, size: str, response_format: str, seed: int = 42, 
         "generator": generator,
         "num_inference_steps": 20
     }
-    # ipimagenone = load_image("512x512bb.jpeg")
-    # # Conditionally add the ip_adapter_image argument
-    # if ipimage is not None:
-    #     args_dict["ip_adapter_image"] = ipimage
-    #     stable_diffusion.set_ip_adapter_scale(0.5)
-    # else:
-    #     args_dict["ip_adapter_image"] = ipimagenone
-    #     stable_diffusion.set_ip_adapter_scale(0.0)
+    ipimagenone = load_image("512x512bb.jpeg")
+    # Conditionally add the ip_adapter_image argument
+    if ipimage is not None:
+        args_dict["ip_adapter_image"] = ipimage
+        stable_diffusion.set_ip_adapter_scale(0.5)
+    else:
+        args_dict["ip_adapter_image"] = ipimagenone
+        stable_diffusion.set_ip_adapter_scale(0.0)
 
 
     image = stable_diffusion(**args_dict).images[0]
@@ -180,7 +180,7 @@ async def edits(inrequest: Request):
 
     response_data = None
     try:
-        response_data = image_request(request.prompt, request.size, request.n, tensor_image)
+        response_data = image_request(request.prompt, request.size, request.response_format, request.n, tensor_image)
     
     except Exception as e:
         # Handle exception...

--- a/image_client.py
+++ b/image_client.py
@@ -28,7 +28,7 @@ class CompletionRequest(BaseModel):
     prompt: str
     n: Optional[int] = 42
     image: Optional[UploadFile] = None
-    response_format: Optional[str] = "b64_json"
+    response_format: Optional[str] = "url"
     size: Optional[str] = "1024x1024"
     quality: Optional[str] = "smooth"
     style: Optional[str] = "0.6"
@@ -160,7 +160,7 @@ async def edits(inrequest: Request):
         "prompt": form_data.get("prompt"),
         "n": int(form_data.get("n")) if form_data.get("n") else None,
         "model": form_data.get("model"),
-        "response_format": form_data.get("response_format"),
+        "response_format": form_data.get("response_format") if form_data.get("response_format") else "url",
         "quality": form_data.get("quality"),
         "style": form_data.get("style"),
         "size": form_data.get("size"),


### PR DESCRIPTION
### Problem
The default response type for the image_client is "url". 

### Solution
Responses are now returned as a b64 encoded string which can be decoded on the client's end. 

### Changes
Added a "response_format" function parameter that is used return the response based on the value set by the user. If the user does not provide a value for "response_format" the default value for this parameter is "b64_json". 
EDIT: Switched the default values for "respose_format" back to "URL". 

### Testing
Verified that both "b64_json" and "url" formats work for image generation and image edits. 