### PR TITLE
Fix Stop Condition and Temperature Handling

### DIFF
--- a/llm_exl2_dynamic_gen.py
+++ b/llm_exl2_dynamic_gen.py
@@ -463,7 +463,7 @@ def process_prompts():
                         preferred_eos.append(stop_at)
 
                     gen_settings = ExLlamaV2Sampler.Settings()
-                    gen_settings.temperature = 2.0 if temperature>2 else temperature  # To make sure the temperature value does not exceed 1
+                    gen_settings.temperature = 2.0 if temperature>2 else temperature  # To make sure the temperature value does not exceed 2
 
                     job = ExLlamaV2DynamicJob(
                         input_ids = ids,

--- a/llm_exl2_dynamic_gen.py
+++ b/llm_exl2_dynamic_gen.py
@@ -202,8 +202,6 @@ def get_stop_conditions(tokenizer):
     # get_stop_condition special case if model is llama3 
     if "llama3" in repo_str:
         return [tokenizer.single_id("<|eot_id|>"), tokenizer.eos_token_id]
-    # elif prompt_format == "granite":
-    #     return [tokenizer.eos_token_id, "\n\nQuestion:"]
     else:
         return [tokenizer.eos_token_id]
 
@@ -465,12 +463,12 @@ def process_prompts():
                         preferred_eos.append(stop_at)
 
                     gen_settings = ExLlamaV2Sampler.Settings()
-                    gen_settings.temperature = 1.0 if temperature>1 else temperature  # To make sure the temperature value does not exceed 1
+                    gen_settings.temperature = 2.0 if temperature>2 else temperature  # To make sure the temperature value does not exceed 1
 
                     job = ExLlamaV2DynamicJob(
                         input_ids = ids,
                         max_new_tokens = max_tokens,
-                        stop_conditions = preferred_eos if stop_at is None else [tokenizer.eos_token_id, stop_at],
+                        stop_conditions = preferred_eos,
                         gen_settings = gen_settings,
                         filters = filters,
                         token_healing = healing

--- a/llm_exl2_dynamic_gen_lora.py
+++ b/llm_exl2_dynamic_gen_lora.py
@@ -491,7 +491,7 @@ def process_prompts():
                         preferred_eos.append(stop_at)
 
                     gen_settings = ExLlamaV2Sampler.Settings()
-                    gen_settings.temperature = 2.0 if temperature>2 else temperature  # To make sure the temperature value does not exceed 1
+                    gen_settings.temperature = 2.0 if temperature>2 else temperature  # To make sure the temperature value does not exceed 2
 
                     job = ExLlamaV2DynamicJob(
                         input_ids = ids,

--- a/llm_exl2_dynamic_gen_lora.py
+++ b/llm_exl2_dynamic_gen_lora.py
@@ -204,8 +204,6 @@ def get_stop_conditions(tokenizer):
     # get_stop_condition special case if model is llama3 
     if "llama3" in repo_str:
         return [tokenizer.single_id("<|eot_id|>"), tokenizer.eos_token_id]
-    # elif prompt_format == "granite":
-    #     return [tokenizer.eos_token_id, "\n\nQuestion:"]
     else:
         return [tokenizer.eos_token_id]
 
@@ -493,12 +491,12 @@ def process_prompts():
                         preferred_eos.append(stop_at)
 
                     gen_settings = ExLlamaV2Sampler.Settings()
-                    gen_settings.temperature = 1.0 if temperature>1 else temperature  # To make sure the temperature value does not exceed 1
+                    gen_settings.temperature = 2.0 if temperature>2 else temperature  # To make sure the temperature value does not exceed 1
 
                     job = ExLlamaV2DynamicJob(
                         input_ids = ids,
                         max_new_tokens = max_tokens,
-                        stop_conditions = preferred_eos if stop_at is None else [tokenizer.eos_token_id, stop_at],
+                        stop_conditions = preferred_eos,
                         gen_settings = gen_settings,
                         filters = filters,
                         token_healing = healing


### PR DESCRIPTION
**Problems Addressed**

1. Indefinite Generation with `stop_at` Parameter:
     - When using the Llama3 model with a `stop_at` parameter in the extra body, the generation continues indefinitely if the model doesn't output the specified `stop_at` string. This leads to unexpected behavior and potential resource waste.

2. Temperature Value Handling:
     - According to the OpenAI documentation, the temperature value ranges from 0 to 2. However, the existing code handles it as if it ranges from 0 to 1.

**Solution**
1. Stop Condition Fix:
     - Modified the stop conditions to rely solely on the `preferred_eos` variable. The `stop_at` parameter is already handled within `preferred_eos` in earlier steps of the process.

2. Temperature Range Adjustment:
     - Adjusted the handling of the temperature value to ensure that any value exceeding 2 is limited to 2, adhering to OpenAI's specified range.

**Testing Conducted**
1. Stop Condition Testing:
     - Verified that the generation stops correctly when `stop_at` is reached.
     - Confirmed that the generation completes normally when `stop_at` is not encountered.
     - Tested with various input prompts and `stop_at` values to ensure robust handling.

2. Temperature Value Testing:
     - Checked behavior by passing temperature > 2, confirming that the server sets the upper limit to 2 and processes the job correctly.
