### PR TITLE
Configurable EOS Token Support

### DIFF
--- a/llm_exl2_dynamic_gen.py
+++ b/llm_exl2_dynamic_gen.py
@@ -463,7 +463,7 @@ def process_prompts():
                         preferred_eos.append(stop_at)
 
                     gen_settings = ExLlamaV2Sampler.Settings()
-                    gen_settings.temperature = 2.0 if temperature>2 else temperature  # To make sure the temperature value does not exceed 1
+                    gen_settings.temperature = 2.0 if temperature>2 else temperature  # To make sure the temperature value does not exceed 2
 
                     job = ExLlamaV2DynamicJob(
                         input_ids = ids,

--- a/llm_exl2_dynamic_gen.py
+++ b/llm_exl2_dynamic_gen.py
@@ -202,8 +202,6 @@ def get_stop_conditions(tokenizer):
     # get_stop_condition special case if model is llama3 
     if "llama3" in repo_str:
         return [tokenizer.single_id("<|eot_id|>"), tokenizer.eos_token_id]
-    # elif prompt_format == "granite":
-    #     return [tokenizer.eos_token_id, "\n\nQuestion:"]
     else:
         return [tokenizer.eos_token_id]
 
@@ -465,12 +463,12 @@ def process_prompts():
                         preferred_eos.append(stop_at)
 
                     gen_settings = ExLlamaV2Sampler.Settings()
-                    gen_settings.temperature = 1.0 if temperature>1 else temperature  # To make sure the temperature value does not exceed 1
+                    gen_settings.temperature = 2.0 if temperature>2 else temperature  # To make sure the temperature value does not exceed 1
 
                     job = ExLlamaV2DynamicJob(
                         input_ids = ids,
                         max_new_tokens = max_tokens,
-                        stop_conditions = preferred_eos if stop_at is None else [tokenizer.eos_token_id, stop_at],
+                        stop_conditions = preferred_eos,
                         gen_settings = gen_settings,
                         filters = filters,
                         token_healing = healing

--- a/llm_exl2_dynamic_gen.py
+++ b/llm_exl2_dynamic_gen.py
@@ -211,7 +211,7 @@ max_context = int(config.get(repo_str, 'max_context'))
 # the total to distribute dynamically over however many jobs are active at once
 total_context = int(config.get(repo_str, 'total_context'))
 
-config_eos_token = config.get(repo_str, 'eos_token', fallback=None)
+config_eos_token_ids = config.get(repo_str, 'eos_token_ids', fallback=None)
 
 port = args.port if args.port is not None else config.getint('settings', 'port')
 display_mode = 1
@@ -453,18 +453,19 @@ def process_prompts():
                     #streamer.append(stream)
                     #prompt_ids.append(prompt_id)
 
-                    preferred_eos = [tokenizer.single_id(config_eos_token)] if config_eos_token is not None else [tokenizer.eos_token_id]
-
+                    eos_token_ids = [tokenizer.eos_token_id]
+                    if config_eos_token_ids is not None:
+                        eos_token_ids.extend([int(c) for c in config_eos_token_ids.split(',')])
                     if stop_at is not None:
-                        preferred_eos.append(stop_at)
-
+                        eos_token_ids.append(stop_at)
+                                   
                     gen_settings = ExLlamaV2Sampler.Settings()
                     gen_settings.temperature = 2.0 if temperature>2 else temperature  # To make sure the temperature value does not exceed 2
 
                     job = ExLlamaV2DynamicJob(
                         input_ids = ids,
                         max_new_tokens = max_tokens,
-                        stop_conditions = preferred_eos,
+                        stop_conditions = eos_token_ids,
                         gen_settings = gen_settings,
                         filters = filters,
                         token_healing = healing

--- a/llm_exl2_dynamic_gen_lora.py
+++ b/llm_exl2_dynamic_gen_lora.py
@@ -491,7 +491,7 @@ def process_prompts():
                         preferred_eos.append(stop_at)
 
                     gen_settings = ExLlamaV2Sampler.Settings()
-                    gen_settings.temperature = 2.0 if temperature>2 else temperature  # To make sure the temperature value does not exceed 1
+                    gen_settings.temperature = 2.0 if temperature>2 else temperature  # To make sure the temperature value does not exceed 2
 
                     job = ExLlamaV2DynamicJob(
                         input_ids = ids,

--- a/llm_exl2_dynamic_gen_lora.py
+++ b/llm_exl2_dynamic_gen_lora.py
@@ -200,13 +200,6 @@ class JobStatusDisplay:
         if self.console_line is not None:
             print(term.move_xy(0, self.console_line) + self.display_text)
 
-def get_stop_conditions(tokenizer):
-    # get_stop_condition special case if model is llama3 
-    if "llama3" in repo_str:
-        return [tokenizer.single_id("<|eot_id|>"), tokenizer.eos_token_id]
-    else:
-        return [tokenizer.eos_token_id]
-
 
 configini = configparser.ConfigParser()
 configini.read('config.ini')
@@ -219,6 +212,8 @@ max_context = int(configini.get(repo_str, 'max_context'))
 # Total number of tokens to allocate space for. This is not the max_seq_len supported by the model but
 # the total to distribute dynamically over however many jobs are active at once
 total_context = int(configini.get(repo_str, 'total_context'))
+
+config_eos_token = configini.get(repo_str, 'eos_token', fallback=None)
 
 port = args.port if args.port is not None else configini.getint('settings', 'port')
 display_mode = 1
@@ -485,7 +480,7 @@ def process_prompts():
                     #streamer.append(stream)
                     #prompt_ids.append(prompt_id)
 
-                    preferred_eos = get_stop_conditions(tokenizer)
+                    preferred_eos = [tokenizer.single_id(config_eos_token)] if config_eos_token is not None else [tokenizer.eos_token_id]
 
                     if stop_at is not None:
                         preferred_eos.append(stop_at)

--- a/llm_exl2_dynamic_gen_lora.py
+++ b/llm_exl2_dynamic_gen_lora.py
@@ -213,7 +213,7 @@ max_context = int(configini.get(repo_str, 'max_context'))
 # the total to distribute dynamically over however many jobs are active at once
 total_context = int(configini.get(repo_str, 'total_context'))
 
-config_eos_token = configini.get(repo_str, 'eos_token', fallback=None)
+config_eos_token_ids = configini.get(repo_str, 'eos_token_ids', fallback=None)
 
 port = args.port if args.port is not None else configini.getint('settings', 'port')
 display_mode = 1
@@ -480,18 +480,19 @@ def process_prompts():
                     #streamer.append(stream)
                     #prompt_ids.append(prompt_id)
 
-                    preferred_eos = [tokenizer.single_id(config_eos_token)] if config_eos_token is not None else [tokenizer.eos_token_id]
-
+                    eos_token_ids = [tokenizer.eos_token_id]
+                    if config_eos_token_ids is not None:
+                        eos_token_ids.extend([int(c) for c in config_eos_token_ids.split(',')])
                     if stop_at is not None:
-                        preferred_eos.append(stop_at)
-
+                        eos_token_ids.append(stop_at)
+                        
                     gen_settings = ExLlamaV2Sampler.Settings()
                     gen_settings.temperature = 2.0 if temperature>2 else temperature  # To make sure the temperature value does not exceed 2
 
                     job = ExLlamaV2DynamicJob(
                         input_ids = ids,
                         max_new_tokens = max_tokens,
-                        stop_conditions = preferred_eos,
+                        stop_conditions = eos_token_ids,
                         gen_settings = gen_settings,
                         filters = filters,
                         token_healing = healing

--- a/llm_exl2_dynamic_gen_lora.py
+++ b/llm_exl2_dynamic_gen_lora.py
@@ -204,8 +204,6 @@ def get_stop_conditions(tokenizer):
     # get_stop_condition special case if model is llama3 
     if "llama3" in repo_str:
         return [tokenizer.single_id("<|eot_id|>"), tokenizer.eos_token_id]
-    # elif prompt_format == "granite":
-    #     return [tokenizer.eos_token_id, "\n\nQuestion:"]
     else:
         return [tokenizer.eos_token_id]
 
@@ -493,12 +491,12 @@ def process_prompts():
                         preferred_eos.append(stop_at)
 
                     gen_settings = ExLlamaV2Sampler.Settings()
-                    gen_settings.temperature = 1.0 if temperature>1 else temperature  # To make sure the temperature value does not exceed 1
+                    gen_settings.temperature = 2.0 if temperature>2 else temperature  # To make sure the temperature value does not exceed 1
 
                     job = ExLlamaV2DynamicJob(
                         input_ids = ids,
                         max_new_tokens = max_tokens,
-                        stop_conditions = preferred_eos if stop_at is None else [tokenizer.eos_token_id, stop_at],
+                        stop_conditions = preferred_eos,
                         gen_settings = gen_settings,
                         filters = filters,
                         token_healing = healing


### PR DESCRIPTION
**Description**
This pull request introduces the integration of models with different EOS tokens than those used by the default ExllamaV2 tokenizer. This change addresses the need for flexibility in model configurations without the necessity of hardcoding EOS tokens directly into the codebase.

**Key Changes**

- Dynamic EOS Token Configuration: A new optional configuration parameter, eos_token, has been added to the config.ini file. This parameter allows different models to specify their own EOS tokens directly via the configuration file, thus enabling seamless integration of models with unique tokenization requirements.

- Default Behavior: If the eos_token key is not present in config.ini, the system will default to using tokenizer.eos_token_id. This ensures backward compatibility and default behavior that aligns with the ExllamaV2 tokenizer's specifications.

- Custom EOS Token Support: For models requiring a distinct EOS token, such as Llama3, users can now specify this by adding eos_token = under the appropriate section in the config.ini file. This entry should be followed by the specific EOS token value as needed.


**Usage**
Users who need to configure a custom EOS token for a model should add or update the eos_token entry in the config.ini file under the relevant model section. For example:

```
[llama3-70B]
string = llama3-70B
repo = <path to model>
specrepo = <path to spec model>
max_context = <max context len>
total_context = <total context len>
eos_token = <|eot_id|>
```

p.s. This should also cover PR #17 , as it was worked from the branch pushed yesterday.