### PR TITLE
FIX for Issue #18 Server Crash on Exception 

### DIFF
--- a/llm_exl2_dynamic_gen.py
+++ b/llm_exl2_dynamic_gen.py
@@ -420,9 +420,8 @@ async def stream_response(prompt_id, timeout=180):
 def process_prompts():
     global partial_responses
     global prompt_ids2jobs, prompt_length, cancelled_request_ids
-    try:
-
-        while True:
+    while True:
+        try:
             while not prompts.empty() or len(prompt_length):
                 while len(prompt_length) < max_batch_size and not prompts.empty():
                     prompt_id, prompt, max_tokens, stream, temperature, outlines_dict = prompts.get()
@@ -595,29 +594,27 @@ def process_prompts():
                             # Re-add the valid items back to the queue
                             for item in temp_storage:
                                 prompts.put(item)
-
-
-
             else:
                 # Sleep for a short duration when there's no work
                 time.sleep(0.1)  # Sleep for 100 milliseconds
-    except Exception as e:
-        print("Reset server due to ", e)
-        print(traceback.format_exc())
-        for prompt_id in prompt_ids2jobs:
-            job = prompt_ids2jobs[prompt_id]
-            if(job.streamer):
-                ## Generator, yield here..
-                partial_response_data = {
-                    "finish_reason": "stop"
-                }
 
-                responses[prompt_id] = partial_response_data
-            else:
-                print("Error handling for full generation current not implemented")
-            generator.cancel(job)
-        prompt_ids2jobs = {}
-        prompt_length = {}
+        except Exception as e:
+            print("Reset server due to ", e)
+            print(traceback.format_exc())
+            for prompt_id in prompt_ids2jobs:
+                job = prompt_ids2jobs[prompt_id]
+                if(job.streamer):
+                    ## Generator, yield here..
+                    partial_response_data = {
+                        "finish_reason": "stop"
+                    }
+
+                    responses[prompt_id] = partial_response_data
+                else:
+                    print("Error handling for full generation current not implemented")
+                generator.cancel(job)
+            prompt_ids2jobs = {}
+            prompt_length = {}
 
 # Start worker thread
 worker = Thread(target=process_prompts)

--- a/llm_exl2_dynamic_gen_lora.py
+++ b/llm_exl2_dynamic_gen_lora.py
@@ -451,9 +451,8 @@ async def stream_response(prompt_id, timeout=180):
 def process_prompts():
     global partial_responses
     global prompt_ids2jobs, prompt_length, prompt_model, cancelled_request_ids
-    try:
-
-        while True:
+    while True:
+        try:
             while not prompts.empty() or len(prompt_length):
                 while len(prompt_length) < max_batch_size and not prompts.empty():
                     prompt_id, prompt, max_tokens, stream, temperature, rmodel, outlines_dict = prompts.get()
@@ -646,31 +645,29 @@ def process_prompts():
                             # Re-add the valid items back to the queue
                             for item in temp_storage:
                                 prompts.put(item)
-
-
-
             else:
                 # Sleep for a short duration when there's no work
                 time.sleep(0.1)  # Sleep for 100 milliseconds
-    except Exception as e:
-        print("Reset server due to ", e)
-        print(traceback.format_exc())
-        for prompt_id in prompt_ids2jobs:
-            job = prompt_ids2jobs[prompt_id]
-            if(job.streamer):
-                ## Generator, yield here..
-                partial_response_data = {
-                    "finish_reason": "stop"
-                }
+                
+        except Exception as e:
+            print("Reset server due to ", e)
+            print(traceback.format_exc())
+            for prompt_id in prompt_ids2jobs:
+                job = prompt_ids2jobs[prompt_id]
+                if(job.streamer):
+                    ## Generator, yield here..
+                    partial_response_data = {
+                        "finish_reason": "stop"
+                    }
 
-                responses[prompt_id] = partial_response_data
-            else:
-                print("Error handling for full generation current not implemented")
-            generators[job.model].cancel(job)
-            #generator.cancel(job)
-        prompt_ids2jobs = {}
-        prompt_length = {}
-        prompt_model = {}
+                    responses[prompt_id] = partial_response_data
+                else:
+                    print("Error handling for full generation current not implemented")
+                generators[job.model].cancel(job)
+                #generator.cancel(job)
+            prompt_ids2jobs = {}
+            prompt_length = {}
+            prompt_model = {}
 
 # Start worker thread
 worker = Thread(target=process_prompts)


### PR DESCRIPTION
**Issue**
The current codebase has a critical issue where the server hangs whenever an exception is caught in the `try` block of the `process_prompts() `function. This causes any subsequent requests to be hung until the server is restarted.

**Solution**
The root cause was identified as the `while True` logic being inside the `try` block. Since the thread needs to be running regardless of exceptions, the continuous run logic was moved outside of the `try` block. This ensures that the server continues to handle new requests even if an exception occurs within the try block.

**Test Performed**
1. Normal Generation
2. Outlines Generation: Tested Regex, JSON, choice, and stop_at
3. Exception Handling
    - Recreated an error scenario where the regex generation with 'R' (recursion) causes an exception in the outlines generation.
    - Verified that the server can process new requests after the exception, without hanging.
    - Cancelled the error-prone code cell (which continues to run indefinitely). After cancellation, made another request to confirm that the server can process the new request from the same instance without needing a restart.